### PR TITLE
force box version 1.0.1

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,6 +5,7 @@ Vagrant.configure('2') do |config|
   
   # Ubuntu 14.04 x64 with Puppet 3.7.1
   config.vm.box = 'puppetlabs/ubuntu-14.04-64-puppet'
+  config.vm.box_version = '1.0.1'
 
   config.vm.network 'private_network', ip: '192.168.20.20'
   config.vm.network :forwarded_port, guest: 81, host: 8181    #nginx-website


### PR DESCRIPTION
Newer versions of this box bundle a version of Puppet which no longer supports
the `manifestdir` parameter that we are using:

```
==> default: Error: Could not parse application options: invalid option: --manifestdir
```

As a temporary fix, this patch ensures that the box version is one which still
supports the parameter. This should be sufficient enough until I figure out an
appropriate change which would allow us to upgrade.