### PR TITLE
fix syntax error

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -92,7 +92,7 @@ class php54 {
     owner   => root,
     group   => root,
     mode    => 664,
-    before => [File ['/etc/php5/fpm/pool.d/www.conf'], File ['/etc/php5/cli/pool.d/www.conf']]
+    before => [File['/etc/php5/fpm/pool.d/www.conf'], File['/etc/php5/cli/pool.d/www.conf']]
   }
 
   file { '/etc/php5/fpm/pool.d/www.conf':


### PR DESCRIPTION
This line currently causes the following error:

    Error: Could not parse for environment puppet: Syntax error at '[' at
    /tmp/vagrant-puppet/environments/puppet/manifests/default.pp:95:21